### PR TITLE
Enabling Faster Whisper's native hallucination filtering compatible with timestamps

### DIFF
--- a/whisper-service/model_implementations/faster_whisper_model.py
+++ b/whisper-service/model_implementations/faster_whisper_model.py
@@ -81,7 +81,8 @@ class FasterWhisperModel(LocalAgreeModelBase):
             audio_segment,
             initial_prompt=prev_text,
             word_timestamps=True,
-            vad_filter=True
+            vad_filter=True,
+            hallucination_silence_threshold=0.1
         )
 
         segments = []


### PR DESCRIPTION
Enabling the "hallucination_silence_threshold to 0.1, off by default. From source-code:

- Optional[float]
                When word_timestamps is True, skip silent periods longer than this threshold
                (in seconds) when a possible hallucination is detected. set as None.