### PR TITLE
casting transcription to english only

### DIFF
--- a/whisper-service/model_implementations/faster_whisper_model.py
+++ b/whisper-service/model_implementations/faster_whisper_model.py
@@ -81,7 +81,9 @@ class FasterWhisperModel(LocalAgreeModelBase):
             audio_segment,
             initial_prompt=prev_text,
             word_timestamps=True,
-            vad_filter=True
+            vad_filter=True,
+            language="en",
+            multilingual=False
         )
 
         segments = []


### PR DESCRIPTION
Enabling:
language="en",
multilingual=False

From source code:
language: The language spoken in the audio. It should be a language code such
            as "en" or "fr". If not set, the language will be detected in the first 30 seconds
            of audio.
multilingual (not strictly nescessary): disabled by default but disables detecting language on every segment           